### PR TITLE
Feature/6-chat 채팅방 생성 API 추가

### DIFF
--- a/src/main/java/com/example/chat_service/controller/ChatRoomController.java
+++ b/src/main/java/com/example/chat_service/controller/ChatRoomController.java
@@ -1,0 +1,32 @@
+package com.example.chat_service.controller;
+
+import com.example.chat_service.dto.request.chatroom.CreateChatRoomRequest;
+import com.example.chat_service.dto.response.CommonApiResponse;
+import com.example.chat_service.dto.response.chatroom.CreateChatRoomResponse;
+import com.example.chat_service.security.dto.CustomUserDetails;
+import com.example.chat_service.service.ChatRoomService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/chat/rooms")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @PostMapping("")
+    public CommonApiResponse<CreateChatRoomResponse> createRoom(
+            @Valid @RequestBody CreateChatRoomRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        CreateChatRoomResponse response = chatRoomService.createRoom(userDetails.getEmail(), request);
+        return CommonApiResponse.success(HttpStatus.CREATED, response);
+    }
+}

--- a/src/main/java/com/example/chat_service/domain/ChatRoom.java
+++ b/src/main/java/com/example/chat_service/domain/ChatRoom.java
@@ -1,11 +1,20 @@
 package com.example.chat_service.domain;
 
+import com.example.chat_service.dto.request.chatroom.CreateChatRoomRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 @Entity
 public class ChatRoom extends BaseEntity {
 
@@ -41,4 +50,17 @@ public class ChatRoom extends BaseEntity {
     @Min(1)
     @Max(100)
     private Integer memberLimit;
+
+    public static ChatRoom create(CreateChatRoomRequest request) {
+        return ChatRoom.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .avatarUrl(request.getAvatarUrl())
+                .status(RoomStatus.valueOf(request.getStatus()))
+                .type(RoomType.valueOf(request.getType()))
+                .visibility(Visibility.valueOf(request.getVisibility()))
+                .policy(JoinPolicy.valueOf(request.getPolicy()))
+                .memberLimit(request.getMemberLimit())
+                .build();
+    }
 }

--- a/src/main/java/com/example/chat_service/domain/ChatRoomMember.java
+++ b/src/main/java/com/example/chat_service/domain/ChatRoomMember.java
@@ -1,12 +1,21 @@
 package com.example.chat_service.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+import static com.example.chat_service.domain.MemberRole.*;
 import static com.example.chat_service.domain.MemberStatus.ACTIVE;
 import static com.example.chat_service.domain.NotificationSetting.ON;
 
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "chat_room_member", uniqueConstraints = {@UniqueConstraint(columnNames = {"chat_room_id", "user_id"})})
 public class ChatRoomMember extends BaseEntity {
@@ -44,5 +53,17 @@ public class ChatRoomMember extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private NotificationSetting setting = ON;
+
+    public static ChatRoomMember create(ChatRoom chatRoom, User sender, User receiver, LocalDateTime now) {
+        return ChatRoomMember.builder()
+                .chatRoom(chatRoom)
+                .user(receiver)
+                .role(OWNER)
+                .status(ACTIVE)
+                .invitedBy(sender)
+                .joinedAt(now)
+                .setting(ON)
+                .build();
+    }
 
 }

--- a/src/main/java/com/example/chat_service/dto/request/chatroom/CreateChatRoomRequest.java
+++ b/src/main/java/com/example/chat_service/dto/request/chatroom/CreateChatRoomRequest.java
@@ -1,5 +1,6 @@
 package com.example.chat_service.dto.request.chatroom;
 
+import com.example.chat_service.domain.JoinPolicy;
 import com.example.chat_service.domain.RoomStatus;
 import com.example.chat_service.domain.RoomType;
 import com.example.chat_service.domain.Visibility;
@@ -36,6 +37,11 @@ public class CreateChatRoomRequest {
     @ValidEnum(enumClass = Visibility.class)
     @Schema(allowableValues = {"PUBLIC", "PRIVATE"})
     private String visibility;
+
+    @NotNull
+    @ValidEnum(enumClass = JoinPolicy.class)
+    @Schema(allowableValues = {"OPEN", "INVITE_ONLY"})
+    private String policy;
 
     @NotNull
     @Min(1)

--- a/src/main/java/com/example/chat_service/dto/response/chatroom/CreateChatRoomResponse.java
+++ b/src/main/java/com/example/chat_service/dto/response/chatroom/CreateChatRoomResponse.java
@@ -1,0 +1,48 @@
+package com.example.chat_service.dto.response.chatroom;
+
+import com.example.chat_service.domain.ChatRoom;
+import com.example.chat_service.domain.ChatRoomMember;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CreateChatRoomResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private String avatarUrl;
+    private String chatRoomStatus;
+    private String type;
+    private String visibility;
+    private String policy;
+    private int memberLimit;
+    private String role;
+    private String memberStatus;
+    private Long senderId;
+    private LocalDateTime joinedAt;
+    private String roomSetting;
+
+    public static CreateChatRoomResponse from(ChatRoom chatRoom, ChatRoomMember chatRoomMember) {
+        return new CreateChatRoomResponse(
+                chatRoom.getId(),
+                chatRoom.getTitle(),
+                chatRoom.getDescription(),
+                chatRoom.getAvatarUrl(),
+                chatRoom.getStatus().name(),
+                chatRoom.getType().name(),
+                chatRoom.getVisibility().name(),
+                chatRoom.getPolicy().name(),
+                chatRoom.getMemberLimit(),
+                chatRoomMember.getRole().name(),
+                chatRoomMember.getStatus().name(),
+                chatRoomMember.getInvitedBy().getId(),
+                chatRoomMember.getJoinedAt(),
+                chatRoomMember.getSetting().name()
+        );
+    }
+
+}

--- a/src/main/java/com/example/chat_service/exception/DuplicateTitleException.java
+++ b/src/main/java/com/example/chat_service/exception/DuplicateTitleException.java
@@ -1,0 +1,7 @@
+package com.example.chat_service.exception;
+
+public class DuplicateTitleException extends RuntimeException {
+    public DuplicateTitleException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/chat_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/chat_service/exception/GlobalExceptionHandler.java
@@ -60,4 +60,18 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleUserNotFoundException(UserNotFoundException ex) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("message", ex.getMessage());
+        return new ResponseEntity<>(errors, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DuplicateTitleException.class)
+    public ResponseEntity<Map<String, String>> handleDuplicateTitleException(DuplicateTitleException ex) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("message", ex.getMessage());
+        return new ResponseEntity<>(errors, HttpStatus.CONFLICT);
+    }
+
 }

--- a/src/main/java/com/example/chat_service/exception/UserNotFoundException.java
+++ b/src/main/java/com/example/chat_service/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.chat_service.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/chat_service/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/chat_service/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,9 @@
+package com.example.chat_service.repository;
+
+import com.example.chat_service.domain.ChatRoomMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
+}

--- a/src/main/java/com/example/chat_service/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/chat_service/repository/ChatRoomRepository.java
@@ -1,0 +1,11 @@
+package com.example.chat_service.repository;
+
+import com.example.chat_service.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    boolean existsByTitle(String title);
+}

--- a/src/main/java/com/example/chat_service/service/ChatRoomService.java
+++ b/src/main/java/com/example/chat_service/service/ChatRoomService.java
@@ -1,0 +1,45 @@
+package com.example.chat_service.service;
+
+import com.example.chat_service.domain.ChatRoom;
+import com.example.chat_service.domain.ChatRoomMember;
+import com.example.chat_service.domain.User;
+import com.example.chat_service.dto.request.chatroom.CreateChatRoomRequest;
+import com.example.chat_service.dto.response.chatroom.CreateChatRoomResponse;
+import com.example.chat_service.exception.DuplicateTitleException;
+import com.example.chat_service.repository.ChatRoomMemberRepository;
+import com.example.chat_service.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final UserService userService;
+
+    @Transactional
+    public CreateChatRoomResponse createRoom(String email, CreateChatRoomRequest request) {
+        User findUser = userService.findByEmail(email);
+        boolean existChatRoom = chatRoomRepository.existsByTitle(request.getTitle());
+
+        // 채팅방의 title은 고유한 값이다.
+        if (existChatRoom) {
+            throw new DuplicateTitleException("Duplicate Chat Room Title: " + request.getTitle());
+        }
+
+        // ChatRoom 생성 및 반환
+        ChatRoom createChatRoom = ChatRoom.create(request);
+        ChatRoom savedChatRoom = chatRoomRepository.save(createChatRoom);
+
+        LocalDateTime now = LocalDateTime.now();
+        ChatRoomMember chatRoomMember = ChatRoomMember.create(createChatRoom, findUser, findUser, now);
+        ChatRoomMember savedChatRoomMember = chatRoomMemberRepository.save(chatRoomMember);
+
+        return CreateChatRoomResponse.from(savedChatRoom, savedChatRoomMember);
+    }
+}

--- a/src/main/java/com/example/chat_service/service/UserService.java
+++ b/src/main/java/com/example/chat_service/service/UserService.java
@@ -1,21 +1,22 @@
 package com.example.chat_service.service;
 
-import static com.example.chat_service.domain.User.createUser;
-
+import com.example.chat_service.domain.User;
 import com.example.chat_service.dto.response.token.TokenPair;
 import com.example.chat_service.dto.response.user.GetUserInfoResponse;
 import com.example.chat_service.dto.response.user.UserLoginResponse;
 import com.example.chat_service.dto.response.user.UserRegisterResponse;
-import com.example.chat_service.domain.User;
+import com.example.chat_service.exception.UserNotFoundException;
 import com.example.chat_service.repository.UserRepository;
 import com.example.chat_service.security.dto.CustomUserDetails;
 import com.example.chat_service.security.jwt.JwtTokenProvider;
 import com.example.chat_service.utils.PasswordUtils;
 import com.example.chat_service.validator.UserValidator;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.chat_service.domain.User.createUser;
 
 @Slf4j
 @Service
@@ -60,6 +61,12 @@ public class UserService {
         }
 
         throw new IllegalArgumentException("Invalid email or password");
+    }
+
+    @Transactional(readOnly = true)
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("Not Found User Email: " + email));
     }
 
     public GetUserInfoResponse getUserInfo(CustomUserDetails userDetails) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 채팅방 생성 기능 추가: REST 엔드포인트를 통해 제목, 설명, 공개 범위, 유형, 참가 정책, 인원 제한 등을 입력해 채팅방을 만들 수 있습니다. 생성자는 자동으로 멤버로 등록됩니다.
  - 응답에 방 ID, 기본 정보, 생성자의 역할/상태, 초대한 사용자, 가입 시각, 알림 설정 등이 포함됩니다.
- 버그 수정
  - 중복 제목인 경우 생성이 거절되며 충돌(409) 메시지를 제공합니다.
  - 존재하지 않는 사용자로 요청 시 찾을 수 없음(404) 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->